### PR TITLE
Make Browser.get and Tab.close wait for their appropiate target events before returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Browser.get` and `Tab.close` will now wait for their appropiate target events before returning @ccev
+
 ### Added
 
 ### Changed

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -252,11 +252,20 @@ class Browser:
         :param new_tab: open new tab
         :param new_window:  open new window
         :return: Page
+        :raises: asyncio.TimeoutError
         """
         if not self.connection:
             raise RuntimeError("Browser not yet started. use await browser.start()")
 
         if new_tab or new_window:
+            future = asyncio.get_running_loop().create_future()
+            event_type = cdp.target.TargetCreated
+
+            async def get_handler(event: event_type) -> None:
+                future.set_result(event)
+
+            self.connection.add_handler(event_type, get_handler)
+
             # create new target using the browser session
             target_id = await self.connection.send(
                 cdp.target.create_target(
@@ -272,6 +281,9 @@ class Browser:
             )
             connection.browser = self
 
+            await asyncio.wait_for(future, 10)
+            self.connection.remove_handlers(event_type, get_handler)
+
         else:
             # first tab from browser.tabs
             connection = next(filter(lambda item: item.type_ == "page", self.targets))
@@ -279,7 +291,6 @@ class Browser:
             await connection.send(cdp.page.navigate(url))
             connection.browser = self
 
-        await connection.sleep(0.25)
         return connection
 
     async def start(self) -> Browser:

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -261,7 +261,7 @@ class Browser:
             future = asyncio.get_running_loop().create_future()
             event_type = cdp.target.TargetCreated
 
-            async def get_handler(event: event_type) -> None:
+            async def get_handler(event: cdp.target.TargetCreated) -> None:
                 future.set_result(event)
 
             self.connection.add_handler(event_type, get_handler)

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -908,13 +908,17 @@ class Tab(Connection):
         :return:
         :rtype:
         :raises: asyncio.TimeoutError
+        :raises: RuntimeError
         """
+
+        if not self.browser or not self.browser.connection:
+            raise RuntimeError("Browser not yet started. use await browser.start()")
 
         future = asyncio.get_running_loop().create_future()
         event_type = cdp.target.TargetDestroyed
 
-        async def close_handler(event: event_type) -> None:
-            if event.target_id == self.target.target_id:
+        async def close_handler(event: cdp.target.TargetDestroyed) -> None:
+            if self.target and event.target_id == self.target.target_id:
                 future.set_result(event)
 
         self.browser.connection.add_handler(event_type, close_handler)


### PR DESCRIPTION
This is a PR that solve communication/deadlock issue with websocket: https://github.com/stephanlensky/zendriver/pull/91